### PR TITLE
Remote File Picker/Browser

### DIFF
--- a/lua/async-remote-write/browse.lua
+++ b/lua/async-remote-write/browse.lua
@@ -179,43 +179,26 @@ function M.show_files_in_telescope(files, base_url)
     local conf = require('telescope.config').values
     local actions = require('telescope.actions')
     local action_state = require('telescope.actions.state')
-    local themes = require('telescope.themes')
-    local previewers = require('telescope.previewers')
 
     -- Check if nvim-web-devicons is available for prettier icons
     local has_devicons, devicons = pcall(require, 'nvim-web-devicons')
 
-    -- Setup Telescope highlights if not already done
-    if not M.highlights_created then
-        vim.api.nvim_set_hl(0, "TelRemoteDir", { link = "Directory", default = true })
-        vim.api.nvim_set_hl(0, "TelRemoteFile", { link = "Normal", default = true })
-        vim.api.nvim_set_hl(0, "TelRemoteParent", { link = "Special", default = true })
-        M.highlights_created = true
-    end
-
     -- Create a picker
-    pickers.new(themes.get_dropdown(), {
+    pickers.new({}, {
         prompt_title = "Remote Files: " .. base_url,
         finder = finders.new_table({
             results = files,
             entry_maker = function(entry)
-                local icon, hl
-                local display
+                local icon, icon_hl
 
                 if entry.name == ".." then
                     -- Parent directory
-                    icon = "⬆️  "
-                    hl = "TelRemoteParent"
-                    display = function(entry_value)
-                        return icon .. entry_value.name, { { { 0, #icon }, hl } }
-                    end
+                    icon = "⬆️ "
+                    icon_hl = "Special"
                 elseif entry.is_dir then
                     -- Directory
-                    icon = "📁  "
-                    hl = "TelRemoteDir"
-                    display = function(entry_value)
-                        return icon .. entry_value.name, { { { 0, #icon }, hl } }
-                    end
+                    icon = "📁 "
+                    icon_hl = "Directory"
                 else
                     -- File - try to use devicons if available
                     if has_devicons then
@@ -224,34 +207,17 @@ function M.show_files_in_telescope(files, base_url)
 
                         if dev_icon then
                             icon = dev_icon .. " "
-                            display = function(entry_value)
-                                return icon .. entry_value.name, { { { 0, #icon }, "DevIconDefault" } }
-                            end
-
-                            -- Create highlight for this filetype
-                            local hl_group = "DevIcon" .. ext:upper()
-                            if not vim.fn.hlexists(hl_group) then
-                                vim.api.nvim_set_hl(0, hl_group, { fg = dev_color, default = true })
-                            end
                         else
-                            icon = "📄  "
-                            hl = "TelRemoteFile"
-                            display = function(entry_value)
-                                return icon .. entry_value.name, { { { 0, #icon }, hl } }
-                            end
+                            icon = "📄 "
                         end
                     else
-                        icon = "📄  "
-                        hl = "TelRemoteFile"
-                        display = function(entry_value)
-                            return icon .. entry_value.name, { { { 0, #icon }, hl } }
-                        end
+                        icon = "📄 "
                     end
                 end
 
                 return {
                     value = entry,
-                    display = display,
+                    display = icon .. entry.name,
                     ordinal = entry.name,
                     path = entry.path
                 }

--- a/lua/async-remote-write/browse.lua
+++ b/lua/async-remote-write/browse.lua
@@ -179,21 +179,79 @@ function M.show_files_in_telescope(files, base_url)
     local conf = require('telescope.config').values
     local actions = require('telescope.actions')
     local action_state = require('telescope.actions.state')
+    local themes = require('telescope.themes')
+    local previewers = require('telescope.previewers')
+
+    -- Check if nvim-web-devicons is available for prettier icons
+    local has_devicons, devicons = pcall(require, 'nvim-web-devicons')
+
+    -- Setup Telescope highlights if not already done
+    if not M.highlights_created then
+        vim.api.nvim_set_hl(0, "TelRemoteDir", { link = "Directory", default = true })
+        vim.api.nvim_set_hl(0, "TelRemoteFile", { link = "Normal", default = true })
+        vim.api.nvim_set_hl(0, "TelRemoteParent", { link = "Special", default = true })
+        M.highlights_created = true
+    end
 
     -- Create a picker
-    pickers.new({}, {
+    pickers.new(themes.get_dropdown(), {
         prompt_title = "Remote Files: " .. base_url,
         finder = finders.new_table({
             results = files,
             entry_maker = function(entry)
-                local icon = entry.is_dir and "📁 " or "📄 "
+                local icon, hl
+                local display
+
                 if entry.name == ".." then
-                    icon = "⬆️ "
+                    -- Parent directory
+                    icon = "⬆️  "
+                    hl = "TelRemoteParent"
+                    display = function(entry_value)
+                        return icon .. entry_value.name, { { { 0, #icon }, hl } }
+                    end
+                elseif entry.is_dir then
+                    -- Directory
+                    icon = "📁  "
+                    hl = "TelRemoteDir"
+                    display = function(entry_value)
+                        return icon .. entry_value.name, { { { 0, #icon }, hl } }
+                    end
+                else
+                    -- File - try to use devicons if available
+                    if has_devicons then
+                        local ext = entry.name:match("%.([^%.]+)$") or ""
+                        local dev_icon, dev_color = devicons.get_icon_color(entry.name, ext, { default = true })
+
+                        if dev_icon then
+                            icon = dev_icon .. " "
+                            display = function(entry_value)
+                                return icon .. entry_value.name, { { { 0, #icon }, "DevIconDefault" } }
+                            end
+
+                            -- Create highlight for this filetype
+                            local hl_group = "DevIcon" .. ext:upper()
+                            if not vim.fn.hlexists(hl_group) then
+                                vim.api.nvim_set_hl(0, hl_group, { fg = dev_color, default = true })
+                            end
+                        else
+                            icon = "📄  "
+                            hl = "TelRemoteFile"
+                            display = function(entry_value)
+                                return icon .. entry_value.name, { { { 0, #icon }, hl } }
+                            end
+                        end
+                    else
+                        icon = "📄  "
+                        hl = "TelRemoteFile"
+                        display = function(entry_value)
+                            return icon .. entry_value.name, { { { 0, #icon }, hl } }
+                        end
+                    end
                 end
 
                 return {
                     value = entry,
-                    display = icon .. entry.name,
+                    display = display,
                     ordinal = entry.name,
                     path = entry.path
                 }

--- a/lua/async-remote-write/browse.lua
+++ b/lua/async-remote-write/browse.lua
@@ -17,6 +17,11 @@ function M.browse_remote_directory(url)
     local host = remote_info.host
     local path = remote_info.path
 
+    -- Ensure path starts with a slash (absolute path)
+    if path:sub(1, 1) ~= "/" then
+        path = "/" .. path
+    end
+
     -- Ensure path ends with a slash for consistency
     if path:sub(-1) ~= "/" then
         path = path .. "/"
@@ -111,7 +116,8 @@ function M.parse_find_output(output, path, protocol, host)
                 url_path = "/" .. url_path
             end
 
-            local file_url = protocol .. "://" .. host .. url_path
+            -- Construct the proper URL with double slash after host to ensure path is treated as absolute
+            local file_url = protocol .. "://" .. host .. "/" .. url_path:gsub("^/", "")
 
             table.insert(files, {
                 name = name,

--- a/lua/async-remote-write/browse.lua
+++ b/lua/async-remote-write/browse.lua
@@ -207,17 +207,31 @@ function M.show_files_in_telescope(files, base_url)
 
                         if dev_icon then
                             icon = dev_icon .. " "
+
+                            -- Try to use devicons highlight group if available
+                            local filetype = vim.filetype.match({ filename = entry.name }) or ext
+                            icon_hl = "DevIcon" .. filetype:upper()
+
+                            -- Create highlight group if it doesn't exist
+                            if dev_color and not vim.fn.hlexists(icon_hl) then
+                                vim.api.nvim_set_hl(0, icon_hl, { fg = dev_color, default = true })
+                            end
                         else
                             icon = "📄 "
+                            icon_hl = "Normal"
                         end
                     else
                         icon = "📄 "
+                        icon_hl = "Normal"
                     end
                 end
 
+                -- Use Telescope's highlighting capabilities
                 return {
                     value = entry,
-                    display = icon .. entry.name,
+                    display = function()
+                        return icon .. entry.name, { { { 0, #icon }, icon_hl } }
+                    end,
                     ordinal = entry.name,
                     path = entry.path
                 }

--- a/lua/async-remote-write/browse.lua
+++ b/lua/async-remote-write/browse.lua
@@ -250,7 +250,7 @@ function M.show_files_in_telescope(files, base_url)
                         M.browse_remote_directory(file.url)
                     else
                         -- If it's a file, open it
-                        operations.simple_open_remote_file(file.url)
+                        operations.open_remote_file(file.url)
                     end
                 end
             end)

--- a/lua/async-remote-write/browse.lua
+++ b/lua/async-remote-write/browse.lua
@@ -1,0 +1,259 @@
+local M = {}
+
+local config = require('async-remote-write.config')
+local utils = require('async-remote-write.utils')
+local operations = require('async-remote-write.operations')
+
+-- Function to browse a remote directory and show results in Telescope
+function M.browse_remote_directory(url)
+    -- Parse the remote URL
+    local remote_info = utils.parse_remote_path(url)
+
+    if not remote_info then
+        utils.log("Invalid remote URL: " .. url, vim.log.levels.ERROR, true, config.config)
+        return
+    end
+
+    local host = remote_info.host
+    local path = remote_info.path
+
+    -- Ensure path ends with a slash for consistency
+    if path:sub(-1) ~= "/" then
+        path = path .. "/"
+    end
+
+    -- Log the browsing operation
+    utils.log("Browsing remote directory: " .. url, vim.log.levels.INFO, true, config.config)
+
+    -- Use a bash script that's compatible with most systems
+    local bash_cmd = [[
+    cd %s && \
+    find . -maxdepth 1 | sort | while read f; do
+      if [ "$f" != "." ]; then
+        if [ -d "$f" ]; then echo "d ${f#./}"; else echo "f ${f#./}"; fi
+      fi
+    done
+    ]]
+
+    local cmd = {"ssh", host, string.format(bash_cmd, vim.fn.shellescape(path))}
+
+    -- Create job to execute command
+    local output = {}
+    local stderr_output = {}
+
+    local job_id = vim.fn.jobstart(cmd, {
+        on_stdout = function(_, data)
+            if data and #data > 0 then
+                for _, line in ipairs(data) do
+                    if line and line ~= "" then
+                        table.insert(output, line)
+                    end
+                end
+            end
+        end,
+        on_stderr = function(_, data)
+            if data and #data > 0 then
+                for _, line in ipairs(data) do
+                    if line and line ~= "" then
+                        table.insert(stderr_output, line)
+                    end
+                end
+            end
+        end,
+        on_exit = function(_, exit_code)
+            if exit_code ~= 0 then
+                vim.schedule(function()
+                    utils.log("Error listing directory: " .. table.concat(stderr_output, "\n"),
+                              vim.log.levels.ERROR, true, config.config)
+                end)
+                return
+            end
+
+            vim.schedule(function()
+                -- Process output to get file list
+                local files = M.parse_find_output(output, path, remote_info.protocol, host)
+
+                -- Check if directory is empty
+                if #files == 0 then
+                    utils.log("Directory is empty", vim.log.levels.INFO, true, config.config)
+                    return
+                end
+
+                -- Show files in Telescope
+                M.show_files_in_telescope(files, url)
+            end)
+        end
+    })
+
+    if job_id <= 0 then
+        utils.log("Failed to start SSH job", vim.log.levels.ERROR, true, config.config)
+    end
+end
+
+-- Function to parse find output into a list of files
+function M.parse_find_output(output, path, protocol, host)
+    local files = {}
+
+    for _, line in ipairs(output) do
+        -- Parse the line (type, name format)
+        local file_type, name = line:match("^([df])%s+(.+)$")
+
+        if file_type and name and name ~= "." and name ~= ".." then
+            -- Check if it's a directory or file
+            local is_dir = (file_type == "d")
+
+            -- Format the full path
+            local full_path = path .. name
+
+            -- Format the URL - ensure we have only one slash after the host
+            local url_path = full_path
+            if url_path:sub(1, 1) ~= "/" then
+                url_path = "/" .. url_path
+            end
+
+            local file_url = protocol .. "://" .. host .. url_path
+
+            table.insert(files, {
+                name = name,
+                path = full_path,
+                url = file_url,
+                is_dir = is_dir,
+                type = file_type
+            })
+        end
+    end
+
+    -- Sort directories first, then files
+    table.sort(files, function(a, b)
+        if a.is_dir and not b.is_dir then
+            return true
+        elseif not a.is_dir and b.is_dir then
+            return false
+        else
+            return a.name < b.name
+        end
+    end)
+
+    -- Add a special entry for the parent directory
+    local parent_url = M.get_parent_directory(protocol .. "://" .. host .. path)
+    if parent_url then
+        table.insert(files, 1, {
+            name = "..",
+            path = M.get_path_from_url(parent_url),
+            url = parent_url,
+            is_dir = true,
+            type = "d" -- It's a directory
+        })
+    end
+
+    return files
+end
+
+-- Extract path from URL
+function M.get_path_from_url(url)
+    local remote_info = utils.parse_remote_path(url)
+    if remote_info then
+        return remote_info.path
+    end
+    return nil
+end
+
+-- Function to show files in Telescope
+function M.show_files_in_telescope(files, base_url)
+    -- Check if Telescope is available
+    local has_telescope, telescope = pcall(require, 'telescope')
+    if not has_telescope then
+        utils.log("Telescope not found. Please install telescope.nvim",
+                  vim.log.levels.ERROR, true, config.config)
+        return
+    end
+
+    local pickers = require('telescope.pickers')
+    local finders = require('telescope.finders')
+    local conf = require('telescope.config').values
+    local actions = require('telescope.actions')
+    local action_state = require('telescope.actions.state')
+
+    -- Create a picker
+    pickers.new({}, {
+        prompt_title = "Remote Files: " .. base_url,
+        finder = finders.new_table({
+            results = files,
+            entry_maker = function(entry)
+                local icon = entry.is_dir and "📁 " or "📄 "
+                if entry.name == ".." then
+                    icon = "⬆️ "
+                end
+
+                return {
+                    value = entry,
+                    display = icon .. entry.name,
+                    ordinal = entry.name,
+                    path = entry.path
+                }
+            end
+        }),
+        sorter = conf.generic_sorter({}),
+        attach_mappings = function(prompt_bufnr, map)
+            -- When an item is selected
+            actions.select_default:replace(function()
+                local selection = action_state.get_selected_entry()
+                actions.close(prompt_bufnr)
+
+                if selection then
+                    local file = selection.value
+
+                    if file.is_dir then
+                        -- If it's a directory, browse into it
+                        M.browse_remote_directory(file.url)
+                    else
+                        -- If it's a file, open it
+                        operations.simple_open_remote_file(file.url)
+                    end
+                end
+            end)
+
+            return true
+        end
+    }):find()
+end
+
+-- Function to get the parent directory of a URL
+function M.get_parent_directory(url)
+    local remote_info = utils.parse_remote_path(url)
+
+    if not remote_info then
+        return nil
+    end
+
+    local host = remote_info.host
+    local path = remote_info.path
+    local protocol = remote_info.protocol
+
+    -- Remove trailing slash if present
+    if path:sub(-1) == "/" then
+        path = path:sub(1, -2)
+    end
+
+    -- Get parent path
+    local parent_path = path:match("^(.+)/[^/]+$")
+
+    if not parent_path then
+        -- We're at the root or a direct child of root
+        if path:match("^/[^/]*$") then
+            -- At root or direct child of root, return root
+            parent_path = "/"
+        else
+            return nil
+        end
+    end
+
+    -- Ensure parent_path ends with a slash for consistency
+    if parent_path:sub(-1) ~= "/" then
+        parent_path = parent_path .. "/"
+    end
+
+    return protocol .. "://" .. host .. parent_path
+end
+
+return M

--- a/lua/async-remote-write/browse.lua
+++ b/lua/async-remote-write/browse.lua
@@ -68,8 +68,7 @@ function M.browse_remote_directory(url)
         on_exit = function(_, exit_code)
             if exit_code ~= 0 then
                 vim.schedule(function()
-                    utils.log("Error listing directory: " .. table.concat(stderr_output, "\n"),
-                              vim.log.levels.ERROR, true, config.config)
+                    utils.log("Error listing directory: " .. table.concat(stderr_output, "\n"), vim.log.levels.ERROR, true, config.config)
                 end)
                 return
             end
@@ -169,8 +168,7 @@ function M.show_files_in_telescope(files, base_url)
     -- Check if Telescope is available
     local has_telescope, telescope = pcall(require, 'telescope')
     if not has_telescope then
-        utils.log("Telescope not found. Please install telescope.nvim",
-                  vim.log.levels.ERROR, true, config.config)
+        utils.log("Telescope not found. Please install telescope.nvim", vim.log.levels.ERROR, true, config.config)
         return
     end
 

--- a/lua/async-remote-write/browse.lua
+++ b/lua/async-remote-write/browse.lua
@@ -250,7 +250,7 @@ function M.show_files_in_telescope(files, base_url)
                         M.browse_remote_directory(file.url)
                     else
                         -- If it's a file, open it
-                        operations.open_remote_file(file.url)
+                        operations.simple_open_remote_file(file.url)
                     end
                 end
             end)

--- a/lua/async-remote-write/browse.lua
+++ b/lua/async-remote-write/browse.lua
@@ -259,7 +259,9 @@ function M.get_parent_directory(url)
         parent_path = parent_path .. "/"
     end
 
-    return protocol .. "://" .. host .. parent_path
+    -- Construct URL with proper format to avoid hostname concatenation issues
+    -- Make sure we properly format with double-slash after host for absolute paths
+    return protocol .. "://" .. host .. "/" .. parent_path:gsub("^/", "")
 end
 
 return M

--- a/lua/async-remote-write/commands.lua
+++ b/lua/async-remote-write/commands.lua
@@ -5,8 +5,18 @@ local utils = require('async-remote-write.utils')
 local operations = require('async-remote-write.operations')
 local process = require('async-remote-write.process')
 local buffer = require('async-remote-write.buffer')
+local browse = require('async-remote-write.browse')
 
 function M.register()
+
+    vim.api.nvim_create_user_command("RemoteBrowse", function(opts)
+        browse.browse_remote_directory(opts.args)
+    end, {
+        nargs = 1,
+        desc = "Browse a remote directory and open files with Telescope",
+        complete = "file"
+    })
+
     -- Add a command to open remote files
     vim.api.nvim_create_user_command("RemoteOpen", function(opts)
         operations.open_remote_file(opts.args)

--- a/lua/async-remote-write/init.lua
+++ b/lua/async-remote-write/init.lua
@@ -8,6 +8,7 @@ local process = require('async-remote-write.process')
 local lsp = require('async-remote-write.lsp')
 local commands = require('async-remote-write.commands')
 local utils = require('async-remote-write.utils')
+local browse = require('async-remote-write.browse')
 
 -- Export key functions for external use
 M.setup = function(opts)
@@ -50,5 +51,6 @@ M.debug_buffer_state = buffer.debug_buffer_state
 M.setup_lsp_integration = lsp.setup_lsp_integration
 M.configure = config.configure
 M.log = utils.log
+M.browse_remote_directory = browse.browse_remote_directory
 
 return M

--- a/lua/async-remote-write/operations.lua
+++ b/lua/async-remote-write/operations.lua
@@ -559,6 +559,7 @@ function M.simple_open_remote_file(url, position)
                 vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, content)
             end
 
+
             vim.api.nvim_buf_set_option(bufnr, 'buflisted', true)  -- Make it show in buffer list
             vim.api.nvim_buf_set_option(bufnr, 'bufhidden', '')    -- Don't hide/delete when not visible
             vim.api.nvim_buf_set_option(bufnr, 'swapfile', true)   -- Use a swapfile (helps persistence)
@@ -577,6 +578,9 @@ function M.simple_open_remote_file(url, position)
             if ext and ext ~= "" then
                 vim.filetype.match({ filename = path })
             end
+
+            local buffer_path = vim.api.nvim_buf_get_name(bufnr)
+            vim.cmd("doautocmd BufReadPost " .. vim.fn.fnameescape(buffer_path))
 
             if position then
                 -- Defer the cursor positioning to ensure buffer is fully loaded

--- a/lua/async-remote-write/operations.lua
+++ b/lua/async-remote-write/operations.lua
@@ -7,7 +7,13 @@ local buffer = require('async-remote-write.buffer')
 local lsp -- Will be required later to avoid circular dependency
 
 -- Helper function to fetch content from a remote server
+-- Update this function in operations.lua
 function M.fetch_remote_content(host, path, callback)
+    -- Ensure path starts with / for SSH commands
+    if path:sub(1, 1) ~= "/" then
+        path = "/" .. path
+    end
+
     local cmd = {"ssh", host, "cat " .. vim.fn.shellescape(path)}
     local output = {}
     local stderr_output = {}
@@ -496,6 +502,11 @@ function M.simple_open_remote_file(url, position)
 
     local host = remote_info.host
     local path = remote_info.path
+
+    -- Ensure path has a leading slash for the SSH command
+    if path:sub(1, 1) ~= "/" then
+        path = "/" .. path
+    end
 
     -- Directly fetch content from remote server
     utils.log("Fetching remote file: " .. url, vim.log.levels.INFO, true, config.config)


### PR DESCRIPTION
This adds a feature where you can browse and open a remote file using:
```
:RemoteBrowse rsync://user@host//path/to/folder
```
It also fixes addressed an issue in the remote telescope recent buffers (another repo) where buffers don't get properly deleted and so cannot be reopened properly.