### PR TITLE
fix: LSP rename doesn't work

### DIFF
--- a/lua/remote-lsp/proxy.py
+++ b/lua/remote-lsp/proxy.py
@@ -84,7 +84,7 @@ def replace_uris(obj, remote, protocol):
         return result
 
     elif isinstance(obj, dict):
-        return {k: replace_uris(v, remote, protocol) for k, v in obj.items()}
+        return {replace_uris(k, remote, protocol): replace_uris(v, remote, protocol) for k, v in obj.items()}
     elif isinstance(obj, list):
         return [replace_uris(item, remote, protocol) for item in obj]
 


### PR DESCRIPTION
clangd renaming doesn't work properly since the file uri in the key didn''t get translated

Note: I haven't test the python code yet, but it works for my plugin https://github.com/Chayanon-Ninyawee/remote-lsp.nvim/blob/main/lua/remote-lsp/scripts/lsp-proxy.py#L155

Here uri that aren't translated:
```json
{
  "id": 6,
  "jsonrpc": "2.0",
  "result": {
    "changes": {
      "file:///home/garfieldcmix/git/KMITL-ComPro-1/lab-5/ex03.c": [
        {
          "newText": "studentMarks",
          "range": {
            "end": {
              "character": 20,
              "line": 5
            },
            "start": {
              "character": 8,
              "line": 5
            }
          }
        },
        {
          "newText": "studentMarks",
          "range": {
            "end": {
              "character": 33,
              "line": 9
            },
            "start": {
              "character": 21,
              "line": 9
            }
          }
        },
        {
          "newText": "studentMarks",
          "range": {
            "end": {
              "character": 33,
              "line": 15
            },
            "start": {
              "character": 21,
              "line": 15
            }
          }
        },
        {
          "newText": "studentMarks",
          "range": {
            "end": {
              "character": 38,
              "line": 17
            },
            "start": {
              "character": 26,
              "line": 17
            }
          }
        },
        {
          "newText": "studentMarks",
          "range": {
            "end": {
              "character": 38,
              "line": 18
            },
            "start": {
              "character": 26,
              "line": 18
            }
          }
        }
      ]
    }
  }
}
```